### PR TITLE
fix datasource for grafana cloud

### DIFF
--- a/grafana/provisioning/dashboards/subspace-dashboard-counterpoint.json
+++ b/grafana/provisioning/dashboards/subspace-dashboard-counterpoint.json
@@ -1,3533 +1,3272 @@
 {
     "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": {
-            "type": "grafana",
-            "uid": "-- Grafana --"
-          },
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "target": {
-            "limit": 100,
-            "matchAny": false,
-            "tags": [],
+        "list": [ {
+            "builtIn": 1,
+            "datasource": {
+                "type": "grafana",
+                "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+                "limit": 100,
+                "matchAny": false,
+                "tags": [ ],
+                "type": "dashboard"
+            },
             "type": "dashboard"
-          },
-          "type": "dashboard"
-        }
-      ]
+        } ]
     },
     "description": "Monitor the health and progress of your Subspace node",
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
     "id": 4,
-    "links": [],
+    "links": [ ],
     "liveNow": false,
-    "panels": [
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 0
-        },
-        "id": 34,
-        "panels": [],
-        "title": "Hardware",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "description": "Busy state of all CPU cores together",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
+    "panels": [ {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
             },
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
+            "id": 34,
+            "panels": [ ],
+            "title": "Hardware",
+            "type": "row"
+        },
+        {
+            "datasource": {},
+            "description": "Busy state of all CPU cores together",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [ {
+                        "options": {
+                            "match": "null",
+                            "result": {
+                                "text": "N/A"
+                            }
+                        },
+                        "type": "special"
+                    } ],
+                    "max": 100,
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "rgba(50, 172, 45, 0.97)",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 85
+                            },
+                            {
+                                "color": "rgba(245, 54, 54, 0.9)",
+                                "value": 95
+                            }
+                        ]
+                    },
+                    "unit": "percent"
                 },
-                "type": "special"
-              }
-            ],
-            "max": 100,
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "rgba(50, 172, 45, 0.97)",
-                  "value": null
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 0,
+                "y": 1
+            },
+            "id": 6,
+            "links": [ ],
+            "options": {
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [ "lastNotNull" ],
+                    "fields": "",
+                    "values": false
+                },
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
+                },
+                "editorMode": "code",
+                "expr": "(((count(count(node_cpu_seconds_total) by (cpu))) - avg(sum by (mode)(rate(node_cpu_seconds_total{mode='idle'}[$__rate_interval])))) * 100) / count(count(node_cpu_seconds_total) by (cpu))",
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A"
+            } ],
+            "title": "CPU Busy",
+            "type": "gauge"
+        },
+        {
+            "datasource": {},
+            "description": "Busy state of all CPU cores together (5 min average)",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [ {
+                        "options": {
+                            "match": "null",
+                            "result": {
+                                "text": "N/A"
+                            }
+                        },
+                        "type": "special"
+                    } ],
+                    "max": 100,
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "rgba(50, 172, 45, 0.97)",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 85
+                            },
+                            {
+                                "color": "rgba(245, 54, 54, 0.9)",
+                                "value": 95
+                            }
+                        ]
+                    },
+                    "unit": "percent"
+                },
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 3,
+                "y": 1
+            },
+            "id": 14,
+            "links": [ ],
+            "options": {
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [ "lastNotNull" ],
+                    "fields": "",
+                    "values": false
+                },
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "uid": "${DS_PROMETHEUS}"
+                },
+                "editorMode": "code",
+                "expr": "avg(node_load5) / count(count(node_cpu_seconds_total) by (cpu)) * 100",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 1,
+                "range": true,
+                "refId": "A",
+                "step": 240
+            } ],
+            "title": "Sys Load (5m avg)",
+            "type": "gauge"
+        },
+        {
+            "datasource": {},
+            "description": "Busy state of all CPU cores together (15 min average)",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [ {
+                        "options": {
+                            "match": "null",
+                            "result": {
+                                "text": "N/A"
+                            }
+                        },
+                        "type": "special"
+                    } ],
+                    "max": 100,
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "rgba(50, 172, 45, 0.97)",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 85
+                            },
+                            {
+                                "color": "rgba(245, 54, 54, 0.9)",
+                                "value": 95
+                            }
+                        ]
+                    },
+                    "unit": "percent"
+                },
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 6,
+                "y": 1
+            },
+            "id": 16,
+            "links": [ ],
+            "options": {
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [ "lastNotNull" ],
+                    "fields": "",
+                    "values": false
+                },
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "uid": "${DS_PROMETHEUS}"
+                },
+                "editorMode": "code",
+                "expr": "avg(node_load15) /  count(count(node_cpu_seconds_total) by (cpu)) * 100",
+                "hide": false,
+                "intervalFactor": 1,
+                "range": true,
+                "refId": "A",
+                "step": 240
+            } ],
+            "title": "Sys Load (15m avg)",
+            "type": "gauge"
+        },
+        {
+            "datasource": {},
+            "description": "Non available RAM memory",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "decimals": 0,
+                    "mappings": [ ],
+                    "max": 100,
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "rgba(50, 172, 45, 0.97)",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 80
+                            },
+                            {
+                                "color": "rgba(245, 54, 54, 0.9)",
+                                "value": 90
+                            }
+                        ]
+                    },
+                    "unit": "percent"
+                },
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 9,
+                "y": 1
+            },
+            "hideTimeOverride": false,
+            "id": 10,
+            "links": [ ],
+            "options": {
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [ "lastNotNull" ],
+                    "fields": "",
+                    "values": false
+                },
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                    "datasource": {
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "editorMode": "code",
+                    "expr": "((node_memory_MemTotal_bytes - node_memory_MemFree_byte) / (node_memory_MemTotal_bytes)) * 100",
+                    "format": "time_series",
+                    "hide": true,
+                    "intervalFactor": 1,
+                    "range": true,
+                    "refId": "A",
+                    "step": 240
                 },
                 {
-                  "color": "rgba(237, 129, 40, 0.89)",
-                  "value": 85
-                },
-                {
-                  "color": "rgba(245, 54, 54, 0.9)",
-                  "value": 95
+                    "datasource": {
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "editorMode": "code",
+                    "expr": "100 - ((node_memory_MemAvailable_bytes * 100) / node_memory_MemTotal_bytes)",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 1,
+                    "range": true,
+                    "refId": "B",
+                    "step": 240
                 }
-              ]
-            },
-            "unit": "percent"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 0,
-          "y": 1
-        },
-        "id": 6,
-        "links": [],
-        "options": {
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
             ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true
+            "title": "RAM Used",
+            "type": "gauge"
         },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
+        {
+            "datasource": {},
+            "description": "Used Swap",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [ {
+                        "options": {
+                            "match": "null",
+                            "result": {
+                                "text": "N/A"
+                            }
+                        },
+                        "type": "special"
+                    } ],
+                    "max": 100,
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "rgba(50, 172, 45, 0.97)",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 10
+                            },
+                            {
+                                "color": "rgba(245, 54, 54, 0.9)",
+                                "value": 25
+                            }
+                        ]
+                    },
+                    "unit": "percent"
+                },
+                "overrides": [ ]
             },
-            "editorMode": "code",
-            "expr": "(((count(count(node_cpu_seconds_total) by (cpu))) - avg(sum by (mode)(rate(node_cpu_seconds_total{mode='idle'}[$__rate_interval])))) * 100) / count(count(node_cpu_seconds_total) by (cpu))",
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "CPU Busy",
-        "type": "gauge"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
+            "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 12,
+                "y": 1
+            },
+            "id": 18,
+            "links": [ ],
+            "options": {
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [ "lastNotNull" ],
+                    "fields": "",
+                    "values": false
+                },
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "uid": "${DS_PROMETHEUS}"
+                },
+                "editorMode": "code",
+                "expr": "((node_memory_SwapTotal_bytes - node_memory_SwapFree_bytes) / (node_memory_SwapTotal_bytes)) * 100",
+                "intervalFactor": 1,
+                "range": true,
+                "refId": "A",
+                "step": 240
+            } ],
+            "title": "SWAP Used",
+            "type": "gauge"
         },
-        "description": "Busy state of all CPU cores together (5 min average)",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
+        {
+            "datasource": {},
+            "description": "Used Root FS",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [ {
+                        "options": {
+                            "match": "null",
+                            "result": {
+                                "text": "N/A"
+                            }
+                        },
+                        "type": "special"
+                    } ],
+                    "max": 100,
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "rgba(50, 172, 45, 0.97)",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 80
+                            },
+                            {
+                                "color": "rgba(245, 54, 54, 0.9)",
+                                "value": 90
+                            }
+                        ]
+                    },
+                    "unit": "percent"
+                },
+                "overrides": [ ]
             },
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
+            "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 15,
+                "y": 1
+            },
+            "id": 20,
+            "links": [ ],
+            "options": {
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [ "lastNotNull" ],
+                    "fields": "",
+                    "values": false
                 },
-                "type": "special"
-              }
-            ],
-            "max": 100,
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "rgba(50, 172, 45, 0.97)",
-                  "value": null
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "uid": "${DS_PROMETHEUS}"
                 },
-                {
-                  "color": "rgba(237, 129, 40, 0.89)",
-                  "value": 85
+                "editorMode": "code",
+                "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=\"/\",fstype!=\"rootfs\"} * 100) / node_filesystem_size_bytes{mountpoint=\"/\",fstype!=\"rootfs\"})",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "range": true,
+                "refId": "A",
+                "step": 240
+            } ],
+            "title": "Root FS Used",
+            "type": "gauge"
+        },
+        {
+            "datasource": {},
+            "description": "Total number of CPU cores",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [ {
+                        "options": {
+                            "match": "null",
+                            "result": {
+                                "text": "N/A"
+                            }
+                        },
+                        "type": "special"
+                    } ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "short"
                 },
-                {
-                  "color": "rgba(245, 54, 54, 0.9)",
-                  "value": 95
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 2,
+                "w": 2,
+                "x": 18,
+                "y": 1
+            },
+            "id": 22,
+            "links": [ ],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [ "lastNotNull" ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "uid": "${DS_PROMETHEUS}"
+                },
+                "editorMode": "code",
+                "expr": "count(count(node_cpu_seconds_total) by (cpu))",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "",
+                "range": true,
+                "refId": "A",
+                "step": 240
+            } ],
+            "title": "CPU Cores",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "description": "System uptime",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "decimals": 1,
+                    "mappings": [ {
+                        "options": {
+                            "match": "null",
+                            "result": {
+                                "text": "N/A"
+                            }
+                        },
+                        "type": "special"
+                    } ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "s"
+                },
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 2,
+                "w": 4,
+                "x": 20,
+                "y": 1
+            },
+            "hideTimeOverride": true,
+            "id": 24,
+            "links": [ ],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [ "lastNotNull" ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "uid": "${DS_PROMETHEUS}"
+                },
+                "editorMode": "code",
+                "expr": "node_time_seconds - node_boot_time_seconds",
+                "intervalFactor": 1,
+                "range": true,
+                "refId": "A",
+                "step": 240
+            } ],
+            "title": "Uptime",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "description": "Total RootFS",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "decimals": 0,
+                    "mappings": [ {
+                        "options": {
+                            "match": "null",
+                            "result": {
+                                "text": "N/A"
+                            }
+                        },
+                        "type": "special"
+                    } ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "rgba(50, 172, 45, 0.97)",
+                                "value": null
+                            },
+                            {
+                                "color": "rgba(237, 129, 40, 0.89)",
+                                "value": 70
+                            },
+                            {
+                                "color": "rgba(245, 54, 54, 0.9)",
+                                "value": 90
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 2,
+                "w": 2,
+                "x": 18,
+                "y": 3
+            },
+            "id": 26,
+            "links": [ ],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [ "lastNotNull" ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "uid": "${DS_PROMETHEUS}"
+                },
+                "editorMode": "code",
+                "expr": "node_filesystem_size_bytes{mountpoint=\"/\",fstype!=\"rootfs\"}",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 1,
+                "range": true,
+                "refId": "A",
+                "step": 240
+            } ],
+            "title": "RootFS Total",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "description": "Total RAM",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "decimals": 0,
+                    "mappings": [ {
+                        "options": {
+                            "match": "null",
+                            "result": {
+                                "text": "N/A"
+                            }
+                        },
+                        "type": "special"
+                    } ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 2,
+                "w": 2,
+                "x": 20,
+                "y": 3
+            },
+            "id": 28,
+            "links": [ ],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [ "lastNotNull" ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "uid": "${DS_PROMETHEUS}"
+                },
+                "editorMode": "code",
+                "expr": "node_memory_MemTotal_bytes",
+                "intervalFactor": 1,
+                "range": true,
+                "refId": "A",
+                "step": 240
+            } ],
+            "title": "RAM Total",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "description": "Total SWAP",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "decimals": 0,
+                    "mappings": [ {
+                        "options": {
+                            "match": "null",
+                            "result": {
+                                "text": "N/A"
+                            }
+                        },
+                        "type": "special"
+                    } ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 2,
+                "w": 2,
+                "x": 22,
+                "y": 3
+            },
+            "id": 30,
+            "links": [ ],
+            "maxDataPoints": 100,
+            "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [ "lastNotNull" ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "uid": "${DS_PROMETHEUS}"
+                },
+                "editorMode": "code",
+                "expr": "node_memory_SwapTotal_bytes",
+                "intervalFactor": 1,
+                "range": true,
+                "refId": "A",
+                "step": 240
+            } ],
+            "title": "SWAP Total",
+            "type": "stat"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 5
+            },
+            "id": 48,
+            "panels": [ ],
+            "title": "Validator Stats",
+            "type": "row"
+        },
+        {
+            "datasource": {},
+            "description": "Target Substrate blockheight",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "#EAB839",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 0,
+                "y": 6
+            },
+            "id": 44,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [ "last" ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {
+                    "valueSize": 50
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
+                },
+                "editorMode": "builder",
+                "expr": "substrate_block_height{status=\"sync_target\"}",
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A"
+            } ],
+            "title": "Sync Target",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "description": "Finalized Substrate blockheight",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                            "color": "green",
+                            "value": null
+                        } ]
+                    }
+                },
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 3,
+                "y": 6
+            },
+            "id": 46,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [ "last" ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {
+                    "valueSize": 50
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
+                },
+                "editorMode": "builder",
+                "expr": "substrate_block_height{status=\"finalized\"}",
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A"
+            } ],
+            "title": "Sync Finalized",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "description": "Number of syncing Substrate peers",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 6,
+                "y": 6
+            },
+            "id": 50,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [ "last" ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {
+                    "valueSize": 50
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
+                },
+                "editorMode": "builder",
+                "expr": "substrate_sync_peers",
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A"
+            } ],
+            "title": "Syncing Peers",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "description": "Discovered Substrate peerset size",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 9,
+                "y": 6
+            },
+            "id": 52,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [ "last" ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {
+                    "valueSize": 50
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
+                },
+                "expr": "substrate_sub_libp2p_peerset_num_discovered",
+                "refId": "A"
+            } ],
+            "title": "Peer Set",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "description": "Incoming Substrate connections over the last 30s",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 12,
+                "y": 6
+            },
+            "id": 54,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [ "last" ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {
+                    "valueSize": 50
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
+                },
+                "editorMode": "code",
+                "expr": "rate(substrate_sub_libp2p_incoming_connections_total[30s])",
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A"
+            } ],
+            "title": "Incoming / Sec",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "description": "Total number of blocks constructed",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 15,
+                "y": 6
+            },
+            "id": 56,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [ "last" ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {
+                    "valueSize": 50
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
+                },
+                "expr": "substrate_proposer_block_constructed_sum",
+                "refId": "A"
+            } ],
+            "title": "Blocks Constructed",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "description": "Time taken to propose a block",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 18,
+                "y": 6
+            },
+            "id": 58,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [ "last" ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {
+                    "valueSize": 50
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
+                },
+                "editorMode": "builder",
+                "expr": "rate(substrate_proposer_block_proposal_time_count[$__rate_interval])",
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A"
+            } ],
+            "title": "Block Proposal Time",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "description": "Total inhererents created",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 21,
+                "y": 6
+            },
+            "id": 60,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [ "last" ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {
+                    "valueSize": 50
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
+                },
+                "expr": "substrate_proposer_create_inherents_time_count",
+                "refId": "A"
+            } ],
+            "title": "Create Inherents",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 10
+            },
+            "id": 64,
+            "options": {
+                "legend": {
+                    "calcs": [ ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": false
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
                 }
-              ]
             },
-            "unit": "percent"
-          },
-          "overrides": []
+            "pluginVersion": "9.0.6",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
+                },
+                "expr": "rate(substrate_sync_propagated_transactions[1m])",
+                "refId": "A"
+            } ],
+            "title": "SYNC_TXNS [Count]",
+            "type": "timeseries"
         },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 3,
-          "y": 1
-        },
-        "id": 14,
-        "links": [],
-        "options": {
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true
-        },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": [ ]
             },
-            "editorMode": "code",
-            "expr": "avg(node_load5) / count(count(node_cpu_seconds_total) by (cpu)) * 100",
-            "format": "time_series",
-            "hide": false,
-            "intervalFactor": 1,
-            "range": true,
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "Sys Load (5m avg)",
-        "type": "gauge"
-      },
-      {
-        "datasource": {},
-        "description": "Busy state of all CPU cores together (15 min average)",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 10
             },
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
+            "id": 66,
+            "options": {
+                "legend": {
+                    "calcs": [ ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": false
                 },
-                "type": "special"
-              }
-            ],
-            "max": 100,
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "rgba(50, 172, 45, 0.97)",
-                  "value": null
-                },
-                {
-                  "color": "rgba(237, 129, 40, 0.89)",
-                  "value": 85
-                },
-                {
-                  "color": "rgba(245, 54, 54, 0.9)",
-                  "value": 95
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
                 }
-              ]
             },
-            "unit": "percent"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 6,
-          "y": 1
-        },
-        "id": 16,
-        "links": [],
-        "options": {
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true
-        },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "avg(node_load15) /  count(count(node_cpu_seconds_total) by (cpu)) * 100",
-            "hide": false,
-            "intervalFactor": 1,
-            "range": true,
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "Sys Load (15m avg)",
-        "type": "gauge"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "description": "Non available RAM memory",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "decimals": 0,
-            "mappings": [],
-            "max": 100,
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "rgba(50, 172, 45, 0.97)",
-                  "value": null
+            "pluginVersion": "9.0.6",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
                 },
-                {
-                  "color": "rgba(237, 129, 40, 0.89)",
-                  "value": 80
+                "expr": "rate(substrate_block_verification_and_import_time_bucket[1m])",
+                "refId": "A"
+            } ],
+            "title": "BLOCK_VERIFICATION & IMPORT_TIME [Sec]",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
                 },
-                {
-                  "color": "rgba(245, 54, 54, 0.9)",
-                  "value": 90
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 10
+            },
+            "id": 74,
+            "options": {
+                "legend": {
+                    "calcs": [ ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": false
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
                 }
-              ]
             },
-            "unit": "percent"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 9,
-          "y": 1
-        },
-        "hideTimeOverride": false,
-        "id": 10,
-        "links": [],
-        "options": {
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true
-        },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "((node_memory_MemTotal_bytes - node_memory_MemFree_byte) / (node_memory_MemTotal_bytes)) * 100",
-            "format": "time_series",
-            "hide": true,
-            "intervalFactor": 1,
-            "range": true,
-            "refId": "A",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "100 - ((node_memory_MemAvailable_bytes * 100) / node_memory_MemTotal_bytes)",
-            "format": "time_series",
-            "hide": false,
-            "intervalFactor": 1,
-            "range": true,
-            "refId": "B",
-            "step": 240
-          }
-        ],
-        "title": "RAM Used",
-        "type": "gauge"
-      },
-      {
-        "datasource": {},
-        "description": "Used Swap",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
+            "pluginVersion": "9.0.6",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
                 },
-                "type": "special"
-              }
-            ],
-            "max": 100,
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "rgba(50, 172, 45, 0.97)",
-                  "value": null
+                "expr": "rate(substrate_sub_txpool_validations_finished[1m])",
+                "refId": "A"
+            } ],
+            "title": "VALIDATION_FINISHED [Count]",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
                 },
-                {
-                  "color": "rgba(237, 129, 40, 0.89)",
-                  "value": 10
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 16
+            },
+            "id": 70,
+            "options": {
+                "legend": {
+                    "calcs": [ ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": false
                 },
-                {
-                  "color": "rgba(245, 54, 54, 0.9)",
-                  "value": 25
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
                 }
-              ]
             },
-            "unit": "percent"
-          },
-          "overrides": []
+            "pluginVersion": "9.0.6",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
+                },
+                "expr": "rate(substrate_sub_libp2p_requests_in_success_total_bucket[1m])",
+                "refId": "A"
+            } ],
+            "title": "INCOMING_REQ_SUCCESS [Bucket]",
+            "type": "timeseries"
         },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 12,
-          "y": 1
-        },
-        "id": 18,
-        "links": [],
-        "options": {
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true
-        },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": [ ]
             },
-            "editorMode": "code",
-            "expr": "((node_memory_SwapTotal_bytes - node_memory_SwapFree_bytes) / (node_memory_SwapTotal_bytes)) * 100",
-            "intervalFactor": 1,
-            "range": true,
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "SWAP Used",
-        "type": "gauge"
-      },
-      {
-        "datasource": {},
-        "description": "Used Root FS",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 16
             },
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
+            "id": 72,
+            "options": {
+                "legend": {
+                    "calcs": [ ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": false
                 },
-                "type": "special"
-              }
-            ],
-            "max": 100,
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "rgba(50, 172, 45, 0.97)",
-                  "value": null
-                },
-                {
-                  "color": "rgba(237, 129, 40, 0.89)",
-                  "value": 80
-                },
-                {
-                  "color": "rgba(245, 54, 54, 0.9)",
-                  "value": 90
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
                 }
-              ]
             },
-            "unit": "percent"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 15,
-          "y": 1
-        },
-        "id": 20,
-        "links": [],
-        "options": {
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true
-        },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=\"/\",fstype!=\"rootfs\"} * 100) / node_filesystem_size_bytes{mountpoint=\"/\",fstype!=\"rootfs\"})",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "range": true,
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "Root FS Used",
-        "type": "gauge"
-      },
-      {
-        "datasource": {},
-        "description": "Total number of CPU cores",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
+            "pluginVersion": "9.0.6",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
                 },
-                "type": "special"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
+                "expr": "rate(substrate_sub_libp2p_requests_out_success_total_bucket[1m])",
+                "refId": "A"
+            } ],
+            "title": "OUTGOING_REQ_SUCCESS [Bucket]",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
                 },
-                {
-                  "color": "red",
-                  "value": 80
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 16
+            },
+            "id": 68,
+            "options": {
+                "legend": {
+                    "calcs": [ ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": false
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
                 }
-              ]
             },
-            "unit": "short"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 2,
-          "w": 2,
-          "x": 18,
-          "y": 1
-        },
-        "id": 22,
-        "links": [],
-        "maxDataPoints": 100,
-        "options": {
-          "colorMode": "none",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "count(count(node_cpu_seconds_total) by (cpu))",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "",
-            "range": true,
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "CPU Cores",
-        "type": "stat"
-      },
-      {
-        "datasource": {},
-        "description": "System uptime",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "decimals": 1,
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
+            "pluginVersion": "9.0.6",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
                 },
-                "type": "special"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
+                "expr": "rate(substrate_tasks_polling_duration_bucket[1m])",
+                "refId": "A"
+            } ],
+            "title": "POLLING_DURATION [Bucket]",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
                 },
-                {
-                  "color": "red",
-                  "value": 80
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 22
+            },
+            "id": 76,
+            "options": {
+                "legend": {
+                    "calcs": [ ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": false
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
                 }
-              ]
             },
-            "unit": "s"
-          },
-          "overrides": []
+            "pluginVersion": "9.0.6",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
+                },
+                "expr": "rate(substrate_sub_libp2p_network_bytes_total[1m]) / 1000000",
+                "refId": "A"
+            } ],
+            "title": "NETWORK_IN & OUT [MBytes]",
+            "type": "timeseries"
         },
-        "gridPos": {
-          "h": 2,
-          "w": 4,
-          "x": 20,
-          "y": 1
-        },
-        "hideTimeOverride": true,
-        "id": 24,
-        "links": [],
-        "maxDataPoints": 100,
-        "options": {
-          "colorMode": "none",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": [ ]
             },
-            "editorMode": "code",
-            "expr": "node_time_seconds - node_boot_time_seconds",
-            "intervalFactor": 1,
-            "range": true,
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "Uptime",
-        "type": "stat"
-      },
-      {
-        "datasource": {},
-        "description": "Total RootFS",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 22
             },
-            "decimals": 0,
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
+            "id": 78,
+            "options": {
+                "legend": {
+                    "calcs": [ ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": false
                 },
-                "type": "special"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "rgba(50, 172, 45, 0.97)",
-                  "value": null
-                },
-                {
-                  "color": "rgba(237, 129, 40, 0.89)",
-                  "value": 70
-                },
-                {
-                  "color": "rgba(245, 54, 54, 0.9)",
-                  "value": 90
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
                 }
-              ]
             },
-            "unit": "bytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 2,
-          "w": 2,
-          "x": 18,
-          "y": 3
-        },
-        "id": 26,
-        "links": [],
-        "maxDataPoints": 100,
-        "options": {
-          "colorMode": "none",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "node_filesystem_size_bytes{mountpoint=\"/\",fstype!=\"rootfs\"}",
-            "format": "time_series",
-            "hide": false,
-            "intervalFactor": 1,
-            "range": true,
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "RootFS Total",
-        "type": "stat"
-      },
-      {
-        "datasource": {},
-        "description": "Total RAM",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "decimals": 0,
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
+            "pluginVersion": "9.0.6",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
                 },
-                "type": "special"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
+                "expr": "substrate_sub_libp2p_incoming_connections_handshake_errors_total",
+                "refId": "A"
+            } ],
+            "title": "INCOMING_HANDSHAKE_ERRORS [Count]",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
                 },
-                {
-                  "color": "red",
-                  "value": 80
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 22
+            },
+            "id": 80,
+            "options": {
+                "legend": {
+                    "calcs": [ ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": false
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
                 }
-              ]
             },
-            "unit": "bytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 2,
-          "w": 2,
-          "x": 20,
-          "y": 3
-        },
-        "id": 28,
-        "links": [],
-        "maxDataPoints": 100,
-        "options": {
-          "colorMode": "none",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "node_memory_MemTotal_bytes",
-            "intervalFactor": 1,
-            "range": true,
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "RAM Total",
-        "type": "stat"
-      },
-      {
-        "datasource": {},
-        "description": "Total SWAP",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "decimals": 0,
-            "mappings": [
-              {
-                "options": {
-                  "match": "null",
-                  "result": {
-                    "text": "N/A"
-                  }
+            "pluginVersion": "9.0.6",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
                 },
-                "type": "special"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
+                "expr": "substrate_tokio_threads_total",
+                "refId": "A"
+            } ],
+            "title": "TOKIO_THREADS [Count]",
+            "type": "timeseries"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 28
+            },
+            "id": 32,
+            "panels": [ ],
+            "title": "Sync Progress",
+            "type": "row"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "Blockheight",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineStyle": {
+                            "fill": "solid"
+                        },
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "#EAB839",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "none"
                 },
-                {
-                  "color": "red",
-                  "value": 80
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 10,
+                "w": 12,
+                "x": 0,
+                "y": 29
+            },
+            "id": 8,
+            "options": {
+                "legend": {
+                    "calcs": [ ],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
                 }
-              ]
             },
-            "unit": "bytes"
-          },
-          "overrides": []
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "substrate_block_height",
+                "format": "time_series",
+                "instant": false,
+                "interval": "",
+                "legendFormat": "{{status}}",
+                "range": true,
+                "refId": "A"
+            } ],
+            "title": "Syncronisation Progress",
+            "type": "timeseries"
         },
-        "gridPos": {
-          "h": 2,
-          "w": 2,
-          "x": 22,
-          "y": 3
-        },
-        "id": 30,
-        "links": [],
-        "maxDataPoints": 100,
-        "options": {
-          "colorMode": "none",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "#EAB839",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": [ ]
             },
-            "editorMode": "code",
-            "expr": "node_memory_SwapTotal_bytes",
-            "intervalFactor": 1,
-            "range": true,
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "title": "SWAP Total",
-        "type": "stat"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 5
-        },
-        "id": 48,
-        "panels": [],
-        "title": "Validator Stats",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "description": "Target Substrate blockheight",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 29
             },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
+            "id": 2,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [ "last" ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {
+                    "valueSize": 50
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
+                },
+                "editorMode": "builder",
+                "expr": "substrate_block_height{status=\"sync_target\"}",
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A"
+            } ],
+            "title": "Sync Target",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "mappings": [ ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [ {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "#EAB839",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": [ ]
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 12,
+                "y": 34
+            },
+            "id": 94,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                    "calcs": [ "last" ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {
+                    "valueSize": 50
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.1.1",
+            "targets": [ {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "PBFA97CFB590B2093"
+                },
+                "editorMode": "builder",
+                "expr": "substrate_block_height{status=\"best\"}",
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A"
+            } ],
+            "title": "Sync Best",
+            "type": "stat"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 39
+            },
+            "id": 82,
+            "panels": [ ],
+            "title": "Node Stats",
+            "type": "row"
+        },
+        {
+            "aliasColors": {
+                "Apps": "#629E51",
+                "Buffers": "#614D93",
+                "Cache": "#6D1F62",
+                "Cached": "#511749",
+                "Committed": "#508642",
+                "Free": "#0A437C",
+                "Hardware Corrupted - Amount of RAM that the kernel identified as corrupted / not working": "#CFFAFF",
+                "Inactive": "#584477",
+                "PageTables": "#0A50A1",
+                "Page_Tables": "#0A50A1",
+                "RAM_Free": "#E0F9D7",
+                "SWAP Used": "#BF1B00",
+                "Slab": "#806EB7",
+                "Slab_Cache": "#E0752D",
+                "Swap": "#BF1B00",
+                "Swap Used": "#BF1B00",
+                "Swap_Cache": "#C15C17",
+                "Swap_Free": "#2F575E",
+                "Unused": "#EAB839"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {},
+            "decimals": 2,
+            "description": "Basic memory usage",
+            "fieldConfig": {
+                "defaults": {
+                    "links": [ ]
+                },
+                "overrides": [ ]
+            },
+            "fill": 4,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 40
+            },
+            "hiddenSeries": false,
+            "id": 86,
+            "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": 350,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "maxPerRow": 6,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [ {
+                    "alias": "RAM Total",
+                    "color": "#E0F9D7",
+                    "fill": 0,
+                    "stack": false
                 },
                 {
-                  "color": "#EAB839",
-                  "value": 80
+                    "alias": "RAM Cache + Buffer",
+                    "color": "#052B51"
+                },
+                {
+                    "alias": "RAM Free",
+                    "color": "#7EB26D"
+                },
+                {
+                    "alias": "Avaliable",
+                    "color": "#DEDAF7",
+                    "fill": 0,
+                    "stack": false
                 }
-              ]
+            ],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [ {
+                    "datasource": {
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "editorMode": "code",
+                    "expr": "node_memory_MemTotal_bytes",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 1,
+                    "legendFormat": "RAM Total",
+                    "range": true,
+                    "refId": "A",
+                    "step": 240
+                },
+                {
+                    "datasource": {
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "editorMode": "code",
+                    "expr": "node_memory_MemTotal_bytes - node_memory_MemFree_bytes - (node_memory_Cached_bytes + node_memory_Buffers_bytes + node_memory_SReclaimable_bytes)",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 1,
+                    "legendFormat": "RAM Used",
+                    "range": true,
+                    "refId": "B",
+                    "step": 240
+                },
+                {
+                    "datasource": {
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "editorMode": "code",
+                    "expr": "node_memory_Cached_bytes + node_memory_Buffers_bytes + node_memory_SReclaimable_bytes",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "RAM Cache + Buffer",
+                    "range": true,
+                    "refId": "C",
+                    "step": 240
+                },
+                {
+                    "datasource": {
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "editorMode": "code",
+                    "expr": "node_memory_MemFree_bytes",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "RAM Free",
+                    "range": true,
+                    "refId": "D",
+                    "step": 240
+                },
+                {
+                    "datasource": {
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "editorMode": "code",
+                    "expr": "(node_memory_SwapTotal_bytes - node_memory_SwapFree_bytes)",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "SWAP Used",
+                    "range": true,
+                    "refId": "E",
+                    "step": 240
+                }
+            ],
+            "thresholds": [ ],
+            "timeRegions": [ ],
+            "title": "Memory Basic",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": [ ]
+            },
+            "yaxes": [ {
+                    "format": "bytes",
+                    "label": "",
+                    "logBase": 1,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "logBase": 1,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false
             }
-          },
-          "overrides": []
         },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 0,
-          "y": 6
-        },
-        "id": 44,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "last"
+        {
+            "aliasColors": {
+                "Busy": "#EAB839",
+                "Busy Iowait": "#890F02",
+                "Busy other": "#1F78C1",
+                "Idle": "#052B51",
+                "Idle - Waiting for something to happen": "#052B51",
+                "guest": "#9AC48A",
+                "idle": "#052B51",
+                "iowait": "#EAB839",
+                "irq": "#BF1B00",
+                "nice": "#C15C17",
+                "softirq": "#E24D42",
+                "steal": "#FCE2DE",
+                "system": "#508642",
+                "user": "#5195CE"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {},
+            "decimals": 2,
+            "description": "Basic CPU info",
+            "fieldConfig": {
+                "defaults": {
+                    "links": [ ]
+                },
+                "overrides": [ ]
+            },
+            "fill": 4,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 40
+            },
+            "hiddenSeries": false,
+            "id": 84,
+            "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": 250,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "maxPerRow": 6,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": true,
+            "pluginVersion": "9.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [ {
+                    "alias": "Busy Iowait",
+                    "color": "#890F02"
+                },
+                {
+                    "alias": "Idle",
+                    "color": "#7EB26D"
+                },
+                {
+                    "alias": "Busy System",
+                    "color": "#EAB839"
+                },
+                {
+                    "alias": "Busy User",
+                    "color": "#0A437C"
+                },
+                {
+                    "alias": "Busy Other",
+                    "color": "#6D1F62"
+                }
             ],
-            "fields": "",
-            "values": false
-          },
-          "text": {
-            "valueSize": 50
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
-            },
-            "editorMode": "builder",
-            "expr": "substrate_block_height{status=\"sync_target\"}",
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Sync Target",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "description": "Finalized Substrate blockheight",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [ {
+                    "datasource": {
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=\"system\"}[$__rate_interval])) * 100",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 1,
+                    "legendFormat": "Busy System",
+                    "range": true,
+                    "refId": "A",
+                    "step": 240
+                },
                 {
-                  "color": "green",
-                  "value": null
+                    "datasource": {
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='user'}[$__rate_interval])) * 100",
+                    "format": "time_series",
+                    "hide": false,
+                    "intervalFactor": 1,
+                    "legendFormat": "Busy User",
+                    "range": true,
+                    "refId": "B",
+                    "step": 240
+                },
+                {
+                    "datasource": {
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='iowait'}[$__rate_interval])) * 100",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "Busy Iowait",
+                    "range": true,
+                    "refId": "C",
+                    "step": 240
+                },
+                {
+                    "datasource": {
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=~\".*irq\",instance=\"$node\",job=\"$job\"}[$__rate_interval])) * 100",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "Busy IRQs",
+                    "refId": "D",
+                    "step": 240
+                },
+                {
+                    "datasource": {
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum (rate(node_cpu_seconds_total{mode!='idle',mode!='user',mode!='system',mode!='iowait',mode!='irq',mode!='softirq'}[$__rate_interval])) * 100",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "Busy Other",
+                    "range": true,
+                    "refId": "E",
+                    "step": 240
+                },
+                {
+                    "datasource": {
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='idle'}[$__rate_interval])) * 100",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "Idle",
+                    "range": true,
+                    "refId": "F",
+                    "step": 240
                 }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 3,
-          "y": 6
-        },
-        "id": 46,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "last"
             ],
-            "fields": "",
-            "values": false
-          },
-          "text": {
-            "valueSize": 50
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
+            "thresholds": [ ],
+            "timeRegions": [ ],
+            "title": "CPU Basic",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
             },
-            "editorMode": "builder",
-            "expr": "substrate_block_height{status=\"finalized\"}",
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Sync Finalized",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "description": "Number of syncing Substrate peers",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": [ ]
             },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
+            "yaxes": [ {
+                    "$$hashKey": "object:123",
+                    "format": "short",
+                    "label": "",
+                    "logBase": 1,
+                    "max": "100",
+                    "min": "0",
+                    "show": true
                 },
                 {
-                  "color": "red",
-                  "value": 80
+                    "$$hashKey": "object:124",
+                    "format": "short",
+                    "logBase": 1,
+                    "show": false
                 }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 6,
-          "y": 6
-        },
-        "id": 50,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "last"
             ],
-            "fields": "",
-            "values": false
-          },
-          "text": {
-            "valueSize": 50
-          },
-          "textMode": "auto"
+            "yaxis": {
+                "align": false
+            }
         },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
+        {
+            "aliasColors": {
+                "Recv_bytes_eth2": "#7EB26D",
+                "Recv_bytes_lo": "#0A50A1",
+                "Recv_drop_eth2": "#6ED0E0",
+                "Recv_drop_lo": "#E0F9D7",
+                "Recv_errs_eth2": "#BF1B00",
+                "Recv_errs_lo": "#CCA300",
+                "Trans_bytes_eth2": "#7EB26D",
+                "Trans_bytes_lo": "#0A50A1",
+                "Trans_drop_eth2": "#6ED0E0",
+                "Trans_drop_lo": "#E0F9D7",
+                "Trans_errs_eth2": "#BF1B00",
+                "Trans_errs_lo": "#CCA300",
+                "recv_bytes_lo": "#0A50A1",
+                "recv_drop_eth0": "#99440A",
+                "recv_drop_lo": "#967302",
+                "recv_errs_eth0": "#BF1B00",
+                "recv_errs_lo": "#890F02",
+                "trans_bytes_eth0": "#7EB26D",
+                "trans_bytes_lo": "#0A50A1",
+                "trans_drop_eth0": "#99440A",
+                "trans_drop_lo": "#967302",
+                "trans_errs_eth0": "#BF1B00",
+                "trans_errs_lo": "#890F02"
             },
-            "editorMode": "builder",
-            "expr": "substrate_sync_peers",
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Syncing Peers",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "description": "Discovered Substrate peerset size",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {},
+            "description": "Basic network info per interface",
+            "fieldConfig": {
+                "defaults": {
+                    "links": [ ]
+                },
+                "overrides": [ ]
             },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
+            "fill": 4,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 47
+            },
+            "hiddenSeries": false,
+            "id": 90,
+            "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": false,
+                "hideZero": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [ {
+                "alias": "/.*trans.*/",
+                "transform": "negative-Y"
+            } ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [ {
+                    "datasource": {
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(node_network_receive_bytes_total[$__rate_interval])*8",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "recv {{device}}",
+                    "range": true,
+                    "refId": "A",
+                    "step": 240
                 },
                 {
-                  "color": "red",
-                  "value": 80
+                    "datasource": {
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(node_network_transmit_bytes_total[$__rate_interval])*8",
+                    "format": "time_series",
+                    "intervalFactor": 1,
+                    "legendFormat": "trans {{device}} ",
+                    "range": true,
+                    "refId": "B",
+                    "step": 240
                 }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 9,
-          "y": 6
-        },
-        "id": 52,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "last"
             ],
-            "fields": "",
-            "values": false
-          },
-          "text": {
-            "valueSize": 50
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
+            "thresholds": [ ],
+            "timeRegions": [ ],
+            "title": "Network Traffic Basic",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
             },
-            "expr": "substrate_sub_libp2p_peerset_num_discovered",
-            "refId": "A"
-          }
-        ],
-        "title": "Peer Set",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "description": "Incoming Substrate connections over the last 30s",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": [ ]
             },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
+            "yaxes": [ {
+                    "format": "bps",
+                    "logBase": 1,
+                    "show": true
                 },
                 {
-                  "color": "red",
-                  "value": 80
+                    "format": "pps",
+                    "label": "",
+                    "logBase": 1,
+                    "show": false
                 }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 12,
-          "y": 6
-        },
-        "id": 54,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "last"
             ],
-            "fields": "",
-            "values": false
-          },
-          "text": {
-            "valueSize": 50
-          },
-          "textMode": "auto"
+            "yaxis": {
+                "align": false
+            }
         },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {},
+            "decimals": 3,
+            "description": "Disk space used of all filesystems mounted",
+            "fieldConfig": {
+                "defaults": {
+                    "links": [ ]
+                },
+                "overrides": [ ]
             },
-            "editorMode": "code",
-            "expr": "rate(substrate_sub_libp2p_incoming_connections_total[30s])",
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Incoming / Sec",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "description": "Total number of blocks constructed",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
+            "fill": 4,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 47
             },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
+            "height": "",
+            "hiddenSeries": false,
+            "id": 88,
+            "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sort": "current",
+                "sortDesc": false,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "maxPerRow": 6,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [ ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [ {
+                "datasource": {
+                    "uid": "${DS_PROMETHEUS}"
+                },
+                "editorMode": "code",
+                "expr": "100 - ((node_filesystem_avail_bytes{device!~'rootfs'} * 100) / node_filesystem_size_bytes{device!~'rootfs'})",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "{{mountpoint}}",
+                "range": true,
+                "refId": "A",
+                "step": 240
+            } ],
+            "thresholds": [ ],
+            "timeRegions": [ ],
+            "title": "Disk Space Used Basic",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": [ ]
+            },
+            "yaxes": [ {
+                    "format": "percent",
+                    "logBase": 1,
+                    "max": "100",
+                    "min": "0",
+                    "show": true
                 },
                 {
-                  "color": "red",
-                  "value": 80
+                    "format": "short",
+                    "logBase": 1,
+                    "show": true
                 }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 15,
-          "y": 6
-        },
-        "id": 56,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "last"
             ],
-            "fields": "",
-            "values": false
-          },
-          "text": {
-            "valueSize": 50
-          },
-          "textMode": "auto"
+            "yaxis": {
+                "align": false
+            }
         },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {},
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "links": [ ]
+                },
+                "overrides": [ ]
             },
-            "expr": "substrate_proposer_block_constructed_sum",
-            "refId": "A"
-          }
-        ],
-        "title": "Blocks Constructed",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "description": "Time taken to propose a block",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
+            "fill": 2,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 12,
+                "w": 12,
+                "x": 0,
+                "y": 54
             },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
+            "hiddenSeries": false,
+            "id": 12,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideZero": true,
+                "max": true,
+                "min": true,
+                "rightSide": false,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "maxPerRow": 6,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [ {
+                    "alias": "/.*Read.*/",
+                    "transform": "negative-Y"
                 },
                 {
-                  "color": "red",
-                  "value": 80
+                    "alias": "/.*sda_.*/",
+                    "color": "#7EB26D"
+                },
+                {
+                    "alias": "/.*sdb_.*/",
+                    "color": "#EAB839"
+                },
+                {
+                    "alias": "/.*sdc_.*/",
+                    "color": "#6ED0E0"
+                },
+                {
+                    "alias": "/.*sdd_.*/",
+                    "color": "#EF843C"
+                },
+                {
+                    "alias": "/.*sde_.*/",
+                    "color": "#E24D42"
+                },
+                {
+                    "alias": "/.*sda1.*/",
+                    "color": "#584477"
+                },
+                {
+                    "alias": "/.*sda2_.*/",
+                    "color": "#BA43A9"
+                },
+                {
+                    "alias": "/.*sda3_.*/",
+                    "color": "#F4D598"
+                },
+                {
+                    "alias": "/.*sdb1.*/",
+                    "color": "#0A50A1"
+                },
+                {
+                    "alias": "/.*sdb2.*/",
+                    "color": "#BF1B00"
+                },
+                {
+                    "alias": "/.*sdb2.*/",
+                    "color": "#BF1B00"
+                },
+                {
+                    "alias": "/.*sdb3.*/",
+                    "color": "#E0752D"
+                },
+                {
+                    "alias": "/.*sdc1.*/",
+                    "color": "#962D82"
+                },
+                {
+                    "alias": "/.*sdc2.*/",
+                    "color": "#614D93"
+                },
+                {
+                    "alias": "/.*sdc3.*/",
+                    "color": "#9AC48A"
+                },
+                {
+                    "alias": "/.*sdd1.*/",
+                    "color": "#65C5DB"
+                },
+                {
+                    "alias": "/.*sdd2.*/",
+                    "color": "#F9934E"
+                },
+                {
+                    "alias": "/.*sdd3.*/",
+                    "color": "#EA6460"
+                },
+                {
+                    "alias": "/.*sde1.*/",
+                    "color": "#E0F9D7"
+                },
+                {
+                    "alias": "/.*sdd2.*/",
+                    "color": "#FCEACA"
+                },
+                {
+                    "alias": "/.*sde3.*/",
+                    "color": "#F9E2D2"
                 }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 18,
-          "y": 6
-        },
-        "id": 58,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "last"
             ],
-            "fields": "",
-            "values": false
-          },
-          "text": {
-            "valueSize": 50
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
-            },
-            "editorMode": "builder",
-            "expr": "rate(substrate_proposer_block_proposal_time_count[$__rate_interval])",
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Block Proposal Time",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "description": "Total inhererents created",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [ {
+                    "datasource": {
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(node_disk_reads_completed_total[$__rate_interval])",
+                    "intervalFactor": 4,
+                    "legendFormat": "{{device}} - Reads completed",
+                    "range": true,
+                    "refId": "A",
+                    "step": 240
                 },
                 {
-                  "color": "red",
-                  "value": 80
+                    "datasource": {
+                        "uid": "${DS_PROMETHEUS}"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(node_disk_writes_completed_total[$__rate_interval])",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{device}} - Writes completed",
+                    "range": true,
+                    "refId": "B",
+                    "step": 240
                 }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 3,
-          "x": 21,
-          "y": 6
-        },
-        "id": 60,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "last"
             ],
-            "fields": "",
-            "values": false
-          },
-          "text": {
-            "valueSize": 50
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
+            "thresholds": [ ],
+            "timeRegions": [ ],
+            "title": "Disk IOps",
+            "tooltip": {
+                "shared": false,
+                "sort": 0,
+                "value_type": "individual"
             },
-            "expr": "substrate_proposer_create_inherents_time_count",
-            "refId": "A"
-          }
-        ],
-        "title": "Create Inherents",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": [ ]
             },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
+            "yaxes": [ {
+                    "format": "iops",
+                    "label": "IO read (-) / write (+)",
+                    "logBase": 1,
+                    "show": true
                 },
                 {
-                  "color": "red",
-                  "value": 80
+                    "format": "short",
+                    "logBase": 1,
+                    "show": false
                 }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 6,
-          "w": 8,
-          "x": 0,
-          "y": 10
-        },
-        "id": 64,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": false
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "9.0.6",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
-            },
-            "expr": "rate(substrate_sync_propagated_transactions[1m])",
-            "refId": "A"
-          }
-        ],
-        "title": "SYNC_TXNS [Count]",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 6,
-          "w": 8,
-          "x": 8,
-          "y": 10
-        },
-        "id": 66,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": false
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "9.0.6",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
-            },
-            "expr": "rate(substrate_block_verification_and_import_time_bucket[1m])",
-            "refId": "A"
-          }
-        ],
-        "title": "BLOCK_VERIFICATION & IMPORT_TIME [Sec]",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 6,
-          "w": 8,
-          "x": 16,
-          "y": 10
-        },
-        "id": 74,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": false
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "9.0.6",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
-            },
-            "expr": "rate(substrate_sub_txpool_validations_finished[1m])",
-            "refId": "A"
-          }
-        ],
-        "title": "VALIDATION_FINISHED [Count]",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 6,
-          "w": 8,
-          "x": 0,
-          "y": 16
-        },
-        "id": 70,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": false
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "9.0.6",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
-            },
-            "expr": "rate(substrate_sub_libp2p_requests_in_success_total_bucket[1m])",
-            "refId": "A"
-          }
-        ],
-        "title": "INCOMING_REQ_SUCCESS [Bucket]",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 6,
-          "w": 8,
-          "x": 8,
-          "y": 16
-        },
-        "id": 72,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": false
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "9.0.6",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
-            },
-            "expr": "rate(substrate_sub_libp2p_requests_out_success_total_bucket[1m])",
-            "refId": "A"
-          }
-        ],
-        "title": "OUTGOING_REQ_SUCCESS [Bucket]",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 6,
-          "w": 8,
-          "x": 16,
-          "y": 16
-        },
-        "id": 68,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": false
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "9.0.6",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
-            },
-            "expr": "rate(substrate_tasks_polling_duration_bucket[1m])",
-            "refId": "A"
-          }
-        ],
-        "title": "POLLING_DURATION [Bucket]",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 6,
-          "w": 8,
-          "x": 0,
-          "y": 22
-        },
-        "id": 76,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": false
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "9.0.6",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
-            },
-            "expr": "rate(substrate_sub_libp2p_network_bytes_total[1m]) / 1000000",
-            "refId": "A"
-          }
-        ],
-        "title": "NETWORK_IN & OUT [MBytes]",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 6,
-          "w": 8,
-          "x": 8,
-          "y": 22
-        },
-        "id": 78,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": false
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "9.0.6",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
-            },
-            "expr": "substrate_sub_libp2p_incoming_connections_handshake_errors_total",
-            "refId": "A"
-          }
-        ],
-        "title": "INCOMING_HANDSHAKE_ERRORS [Count]",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 6,
-          "w": 8,
-          "x": 16,
-          "y": 22
-        },
-        "id": 80,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": false
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "9.0.6",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
-            },
-            "expr": "substrate_tokio_threads_total",
-            "refId": "A"
-          }
-        ],
-        "title": "TOKIO_THREADS [Count]",
-        "type": "timeseries"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 28
-        },
-        "id": 32,
-        "panels": [],
-        "title": "Sync Progress",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "Blockheight",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineStyle": {
-                "fill": "solid"
-              },
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "#EAB839",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 10,
-          "w": 12,
-          "x": 0,
-          "y": 29
-        },
-        "id": 8,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
-            },
-            "editorMode": "code",
-            "exemplar": false,
-            "expr": "substrate_block_height",
-            "format": "time_series",
-            "instant": false,
-            "interval": "",
-            "legendFormat": "{{status}}",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Syncronisation Progress",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "#EAB839",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 5,
-          "w": 12,
-          "x": 12,
-          "y": 29
-        },
-        "id": 2,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "last"
             ],
-            "fields": "",
-            "values": false
-          },
-          "text": {
-            "valueSize": 50
-          },
-          "textMode": "auto"
+            "yaxis": {
+                "align": false
+            }
         },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
+        {
+            "aliasColors": {
+                "io time": "#890F02"
             },
-            "editorMode": "builder",
-            "expr": "substrate_block_height{status=\"sync_target\"}",
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Sync Target",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {},
+            "decimals": 3,
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "links": [ ]
+                },
+                "overrides": [ ]
             },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
+            "fill": 4,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 12,
+                "w": 12,
+                "x": 12,
+                "y": 54
+            },
+            "hiddenSeries": false,
+            "id": 92,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "max": true,
+                "min": true,
+                "rightSide": false,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [ ],
+            "maxPerRow": 6,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "9.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [ ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [ {
+                "datasource": {
+                    "uid": "${DS_PROMETHEUS}"
+                },
+                "editorMode": "code",
+                "expr": "rate(node_disk_io_time_seconds_total [$__rate_interval])",
+                "format": "time_series",
+                "hide": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "{{device}}",
+                "range": true,
+                "refId": "A",
+                "step": 240
+            } ],
+            "thresholds": [ ],
+            "timeRegions": [ ],
+            "title": "I/O Utilization",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": false,
+                "values": [ ]
+            },
+            "yaxes": [ {
+                    "$$hashKey": "object:1041",
+                    "format": "percentunit",
+                    "label": "%util",
+                    "logBase": 1,
+                    "min": "0",
+                    "show": true
                 },
                 {
-                  "color": "#EAB839",
-                  "value": 80
+                    "$$hashKey": "object:1042",
+                    "format": "s",
+                    "label": "",
+                    "logBase": 1,
+                    "show": false
                 }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 5,
-          "w": 12,
-          "x": 12,
-          "y": 34
-        },
-        "id": 94,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "last"
             ],
-            "fields": "",
-            "values": false
-          },
-          "text": {
-            "valueSize": 50
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "9.1.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
-            },
-            "editorMode": "builder",
-            "expr": "substrate_block_height{status=\"best\"}",
-            "legendFormat": "__auto",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Sync Best",
-        "type": "stat"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 39
-        },
-        "id": 82,
-        "panels": [],
-        "title": "Node Stats",
-        "type": "row"
-      },
-      {
-        "aliasColors": {
-          "Apps": "#629E51",
-          "Buffers": "#614D93",
-          "Cache": "#6D1F62",
-          "Cached": "#511749",
-          "Committed": "#508642",
-          "Free": "#0A437C",
-          "Hardware Corrupted - Amount of RAM that the kernel identified as corrupted / not working": "#CFFAFF",
-          "Inactive": "#584477",
-          "PageTables": "#0A50A1",
-          "Page_Tables": "#0A50A1",
-          "RAM_Free": "#E0F9D7",
-          "SWAP Used": "#BF1B00",
-          "Slab": "#806EB7",
-          "Slab_Cache": "#E0752D",
-          "Swap": "#BF1B00",
-          "Swap Used": "#BF1B00",
-          "Swap_Cache": "#C15C17",
-          "Swap_Free": "#2F575E",
-          "Unused": "#EAB839"
-        },
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "decimals": 2,
-        "description": "Basic memory usage",
-        "fieldConfig": {
-          "defaults": {
-            "links": []
-          },
-          "overrides": []
-        },
-        "fill": 4,
-        "fillGradient": 0,
-        "gridPos": {
-          "h": 7,
-          "w": 12,
-          "x": 0,
-          "y": 40
-        },
-        "hiddenSeries": false,
-        "id": 86,
-        "legend": {
-          "alignAsTable": false,
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "rightSide": false,
-          "show": true,
-          "sideWidth": 350,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 1,
-        "links": [],
-        "maxPerRow": 6,
-        "nullPointMode": "null",
-        "options": {
-          "alertThreshold": true
-        },
-        "percentage": false,
-        "pluginVersion": "9.1.1",
-        "pointradius": 5,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [
-          {
-            "alias": "RAM Total",
-            "color": "#E0F9D7",
-            "fill": 0,
-            "stack": false
-          },
-          {
-            "alias": "RAM Cache + Buffer",
-            "color": "#052B51"
-          },
-          {
-            "alias": "RAM Free",
-            "color": "#7EB26D"
-          },
-          {
-            "alias": "Avaliable",
-            "color": "#DEDAF7",
-            "fill": 0,
-            "stack": false
-          }
-        ],
-        "spaceLength": 10,
-        "stack": true,
-        "steppedLine": false,
-        "targets": [
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "node_memory_MemTotal_bytes",
-            "format": "time_series",
-            "hide": false,
-            "intervalFactor": 1,
-            "legendFormat": "RAM Total",
-            "range": true,
-            "refId": "A",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "node_memory_MemTotal_bytes - node_memory_MemFree_bytes - (node_memory_Cached_bytes + node_memory_Buffers_bytes + node_memory_SReclaimable_bytes)",
-            "format": "time_series",
-            "hide": false,
-            "intervalFactor": 1,
-            "legendFormat": "RAM Used",
-            "range": true,
-            "refId": "B",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "node_memory_Cached_bytes + node_memory_Buffers_bytes + node_memory_SReclaimable_bytes",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "RAM Cache + Buffer",
-            "range": true,
-            "refId": "C",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "node_memory_MemFree_bytes",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "RAM Free",
-            "range": true,
-            "refId": "D",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "(node_memory_SwapTotal_bytes - node_memory_SwapFree_bytes)",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "SWAP Used",
-            "range": true,
-            "refId": "E",
-            "step": 240
-          }
-        ],
-        "thresholds": [],
-        "timeRegions": [],
-        "title": "Memory Basic",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "mode": "time",
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "format": "bytes",
-            "label": "",
-            "logBase": 1,
-            "min": "0",
-            "show": true
-          },
-          {
-            "format": "short",
-            "logBase": 1,
-            "show": false
-          }
-        ],
-        "yaxis": {
-          "align": false
+            "yaxis": {
+                "align": false
+            }
         }
-      },
-      {
-        "aliasColors": {
-          "Busy": "#EAB839",
-          "Busy Iowait": "#890F02",
-          "Busy other": "#1F78C1",
-          "Idle": "#052B51",
-          "Idle - Waiting for something to happen": "#052B51",
-          "guest": "#9AC48A",
-          "idle": "#052B51",
-          "iowait": "#EAB839",
-          "irq": "#BF1B00",
-          "nice": "#C15C17",
-          "softirq": "#E24D42",
-          "steal": "#FCE2DE",
-          "system": "#508642",
-          "user": "#5195CE"
-        },
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "decimals": 2,
-        "description": "Basic CPU info",
-        "fieldConfig": {
-          "defaults": {
-            "links": []
-          },
-          "overrides": []
-        },
-        "fill": 4,
-        "fillGradient": 0,
-        "gridPos": {
-          "h": 7,
-          "w": 12,
-          "x": 12,
-          "y": 40
-        },
-        "hiddenSeries": false,
-        "id": 84,
-        "legend": {
-          "alignAsTable": false,
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "rightSide": false,
-          "show": true,
-          "sideWidth": 250,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 1,
-        "links": [],
-        "maxPerRow": 6,
-        "nullPointMode": "null",
-        "options": {
-          "alertThreshold": true
-        },
-        "percentage": true,
-        "pluginVersion": "9.1.1",
-        "pointradius": 5,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [
-          {
-            "alias": "Busy Iowait",
-            "color": "#890F02"
-          },
-          {
-            "alias": "Idle",
-            "color": "#7EB26D"
-          },
-          {
-            "alias": "Busy System",
-            "color": "#EAB839"
-          },
-          {
-            "alias": "Busy User",
-            "color": "#0A437C"
-          },
-          {
-            "alias": "Busy Other",
-            "color": "#6D1F62"
-          }
-        ],
-        "spaceLength": 10,
-        "stack": true,
-        "steppedLine": false,
-        "targets": [
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=\"system\"}[$__rate_interval])) * 100",
-            "format": "time_series",
-            "hide": false,
-            "intervalFactor": 1,
-            "legendFormat": "Busy System",
-            "range": true,
-            "refId": "A",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='user'}[$__rate_interval])) * 100",
-            "format": "time_series",
-            "hide": false,
-            "intervalFactor": 1,
-            "legendFormat": "Busy User",
-            "range": true,
-            "refId": "B",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode='iowait'}[$__rate_interval])) * 100",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "Busy Iowait",
-            "range": true,
-            "refId": "C",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=~\".*irq\",instance=\"$node\",job=\"$job\"}[$__rate_interval])) * 100",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "Busy IRQs",
-            "refId": "D",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "sum (rate(node_cpu_seconds_total{mode!='idle',mode!='user',mode!='system',mode!='iowait',mode!='irq',mode!='softirq'}[$__rate_interval])) * 100",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "Busy Other",
-            "range": true,
-            "refId": "E",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode='idle'}[$__rate_interval])) * 100",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "Idle",
-            "range": true,
-            "refId": "F",
-            "step": 240
-          }
-        ],
-        "thresholds": [],
-        "timeRegions": [],
-        "title": "CPU Basic",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "mode": "time",
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:123",
-            "format": "short",
-            "label": "",
-            "logBase": 1,
-            "max": "100",
-            "min": "0",
-            "show": true
-          },
-          {
-            "$$hashKey": "object:124",
-            "format": "short",
-            "logBase": 1,
-            "show": false
-          }
-        ],
-        "yaxis": {
-          "align": false
-        }
-      },
-      {
-        "aliasColors": {
-          "Recv_bytes_eth2": "#7EB26D",
-          "Recv_bytes_lo": "#0A50A1",
-          "Recv_drop_eth2": "#6ED0E0",
-          "Recv_drop_lo": "#E0F9D7",
-          "Recv_errs_eth2": "#BF1B00",
-          "Recv_errs_lo": "#CCA300",
-          "Trans_bytes_eth2": "#7EB26D",
-          "Trans_bytes_lo": "#0A50A1",
-          "Trans_drop_eth2": "#6ED0E0",
-          "Trans_drop_lo": "#E0F9D7",
-          "Trans_errs_eth2": "#BF1B00",
-          "Trans_errs_lo": "#CCA300",
-          "recv_bytes_lo": "#0A50A1",
-          "recv_drop_eth0": "#99440A",
-          "recv_drop_lo": "#967302",
-          "recv_errs_eth0": "#BF1B00",
-          "recv_errs_lo": "#890F02",
-          "trans_bytes_eth0": "#7EB26D",
-          "trans_bytes_lo": "#0A50A1",
-          "trans_drop_eth0": "#99440A",
-          "trans_drop_lo": "#967302",
-          "trans_errs_eth0": "#BF1B00",
-          "trans_errs_lo": "#890F02"
-        },
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "description": "Basic network info per interface",
-        "fieldConfig": {
-          "defaults": {
-            "links": []
-          },
-          "overrides": []
-        },
-        "fill": 4,
-        "fillGradient": 0,
-        "gridPos": {
-          "h": 7,
-          "w": 12,
-          "x": 0,
-          "y": 47
-        },
-        "hiddenSeries": false,
-        "id": 90,
-        "legend": {
-          "alignAsTable": false,
-          "avg": false,
-          "current": false,
-          "hideEmpty": false,
-          "hideZero": false,
-          "max": false,
-          "min": false,
-          "rightSide": false,
-          "show": true,
-          "sort": "current",
-          "sortDesc": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 1,
-        "links": [],
-        "nullPointMode": "null",
-        "options": {
-          "alertThreshold": true
-        },
-        "percentage": false,
-        "pluginVersion": "9.1.1",
-        "pointradius": 5,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [
-          {
-            "alias": "/.*trans.*/",
-            "transform": "negative-Y"
-          }
-        ],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "rate(node_network_receive_bytes_total[$__rate_interval])*8",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "recv {{device}}",
-            "range": true,
-            "refId": "A",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "rate(node_network_transmit_bytes_total[$__rate_interval])*8",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "trans {{device}} ",
-            "range": true,
-            "refId": "B",
-            "step": 240
-          }
-        ],
-        "thresholds": [],
-        "timeRegions": [],
-        "title": "Network Traffic Basic",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "mode": "time",
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "format": "bps",
-            "logBase": 1,
-            "show": true
-          },
-          {
-            "format": "pps",
-            "label": "",
-            "logBase": 1,
-            "show": false
-          }
-        ],
-        "yaxis": {
-          "align": false
-        }
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": {},
-        "decimals": 3,
-        "description": "Disk space used of all filesystems mounted",
-        "fieldConfig": {
-          "defaults": {
-            "links": []
-          },
-          "overrides": []
-        },
-        "fill": 4,
-        "fillGradient": 0,
-        "gridPos": {
-          "h": 7,
-          "w": 12,
-          "x": 12,
-          "y": 47
-        },
-        "height": "",
-        "hiddenSeries": false,
-        "id": 88,
-        "legend": {
-          "alignAsTable": false,
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "rightSide": false,
-          "show": true,
-          "sort": "current",
-          "sortDesc": false,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 1,
-        "links": [],
-        "maxPerRow": 6,
-        "nullPointMode": "null",
-        "options": {
-          "alertThreshold": true
-        },
-        "percentage": false,
-        "pluginVersion": "9.1.1",
-        "pointradius": 5,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "100 - ((node_filesystem_avail_bytes{device!~'rootfs'} * 100) / node_filesystem_size_bytes{device!~'rootfs'})",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "{{mountpoint}}",
-            "range": true,
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "thresholds": [],
-        "timeRegions": [],
-        "title": "Disk Space Used Basic",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "mode": "time",
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "format": "percent",
-            "logBase": 1,
-            "max": "100",
-            "min": "0",
-            "show": true
-          },
-          {
-            "format": "short",
-            "logBase": 1,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false
-        }
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "links": []
-          },
-          "overrides": []
-        },
-        "fill": 2,
-        "fillGradient": 0,
-        "gridPos": {
-          "h": 12,
-          "w": 12,
-          "x": 0,
-          "y": 54
-        },
-        "hiddenSeries": false,
-        "id": 12,
-        "legend": {
-          "alignAsTable": true,
-          "avg": true,
-          "current": true,
-          "hideZero": true,
-          "max": true,
-          "min": true,
-          "rightSide": false,
-          "show": true,
-          "total": false,
-          "values": true
-        },
-        "lines": true,
-        "linewidth": 1,
-        "links": [],
-        "maxPerRow": 6,
-        "nullPointMode": "null",
-        "options": {
-          "alertThreshold": true
-        },
-        "percentage": false,
-        "pluginVersion": "9.1.1",
-        "pointradius": 5,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [
-          {
-            "alias": "/.*Read.*/",
-            "transform": "negative-Y"
-          },
-          {
-            "alias": "/.*sda_.*/",
-            "color": "#7EB26D"
-          },
-          {
-            "alias": "/.*sdb_.*/",
-            "color": "#EAB839"
-          },
-          {
-            "alias": "/.*sdc_.*/",
-            "color": "#6ED0E0"
-          },
-          {
-            "alias": "/.*sdd_.*/",
-            "color": "#EF843C"
-          },
-          {
-            "alias": "/.*sde_.*/",
-            "color": "#E24D42"
-          },
-          {
-            "alias": "/.*sda1.*/",
-            "color": "#584477"
-          },
-          {
-            "alias": "/.*sda2_.*/",
-            "color": "#BA43A9"
-          },
-          {
-            "alias": "/.*sda3_.*/",
-            "color": "#F4D598"
-          },
-          {
-            "alias": "/.*sdb1.*/",
-            "color": "#0A50A1"
-          },
-          {
-            "alias": "/.*sdb2.*/",
-            "color": "#BF1B00"
-          },
-          {
-            "alias": "/.*sdb2.*/",
-            "color": "#BF1B00"
-          },
-          {
-            "alias": "/.*sdb3.*/",
-            "color": "#E0752D"
-          },
-          {
-            "alias": "/.*sdc1.*/",
-            "color": "#962D82"
-          },
-          {
-            "alias": "/.*sdc2.*/",
-            "color": "#614D93"
-          },
-          {
-            "alias": "/.*sdc3.*/",
-            "color": "#9AC48A"
-          },
-          {
-            "alias": "/.*sdd1.*/",
-            "color": "#65C5DB"
-          },
-          {
-            "alias": "/.*sdd2.*/",
-            "color": "#F9934E"
-          },
-          {
-            "alias": "/.*sdd3.*/",
-            "color": "#EA6460"
-          },
-          {
-            "alias": "/.*sde1.*/",
-            "color": "#E0F9D7"
-          },
-          {
-            "alias": "/.*sdd2.*/",
-            "color": "#FCEACA"
-          },
-          {
-            "alias": "/.*sde3.*/",
-            "color": "#F9E2D2"
-          }
-        ],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "rate(node_disk_reads_completed_total[$__rate_interval])",
-            "intervalFactor": 4,
-            "legendFormat": "{{device}} - Reads completed",
-            "range": true,
-            "refId": "A",
-            "step": 240
-          },
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "rate(node_disk_writes_completed_total[$__rate_interval])",
-            "intervalFactor": 1,
-            "legendFormat": "{{device}} - Writes completed",
-            "range": true,
-            "refId": "B",
-            "step": 240
-          }
-        ],
-        "thresholds": [],
-        "timeRegions": [],
-        "title": "Disk IOps",
-        "tooltip": {
-          "shared": false,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "mode": "time",
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "format": "iops",
-            "label": "IO read (-) / write (+)",
-            "logBase": 1,
-            "show": true
-          },
-          {
-            "format": "short",
-            "logBase": 1,
-            "show": false
-          }
-        ],
-        "yaxis": {
-          "align": false
-        }
-      },
-      {
-        "aliasColors": {
-          "io time": "#890F02"
-        },
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
-        "decimals": 3,
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "links": []
-          },
-          "overrides": []
-        },
-        "fill": 4,
-        "fillGradient": 0,
-        "gridPos": {
-          "h": 12,
-          "w": 12,
-          "x": 12,
-          "y": 54
-        },
-        "hiddenSeries": false,
-        "id": 92,
-        "legend": {
-          "alignAsTable": true,
-          "avg": true,
-          "current": true,
-          "max": true,
-          "min": true,
-          "rightSide": false,
-          "show": true,
-          "total": false,
-          "values": true
-        },
-        "lines": true,
-        "linewidth": 1,
-        "links": [],
-        "maxPerRow": 6,
-        "nullPointMode": "null",
-        "options": {
-          "alertThreshold": true
-        },
-        "percentage": false,
-        "pluginVersion": "9.1.1",
-        "pointradius": 5,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "datasource": {
-              "uid": "${DS_PROMETHEUS}"
-            },
-            "editorMode": "code",
-            "expr": "rate(node_disk_io_time_seconds_total [$__rate_interval])",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{device}}",
-            "range": true,
-            "refId": "A",
-            "step": 240
-          }
-        ],
-        "thresholds": [],
-        "timeRegions": [],
-        "title": "I/O Utilization",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "mode": "time",
-          "show": false,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:1041",
-            "format": "percentunit",
-            "label": "%util",
-            "logBase": 1,
-            "min": "0",
-            "show": true
-          },
-          {
-            "$$hashKey": "object:1042",
-            "format": "s",
-            "label": "",
-            "logBase": 1,
-            "show": false
-          }
-        ],
-        "yaxis": {
-          "align": false
-        }
-      }
     ],
     "refresh": "30s",
     "schemaVersion": 37,
     "style": "dark",
-    "tags": [],
+    "tags": [ ],
     "templating": {
-      "list": []
+        "list": [ ]
     },
     "time": {
-      "from": "now-3h",
-      "to": "now"
+        "from": "now-3h",
+        "to": "now"
     },
     "timepicker": {},
     "timezone": "",
@@ -3535,4 +3274,4 @@
     "uid": "Ml_pJUW4k",
     "version": 15,
     "weekStart": ""
-  }
+}


### PR DESCRIPTION
I imported your dashboard to grafana cloud and needed to remove the prometheus datasource elements that were not under the target element to get the gauges to work.

The only other difference now between this branch vs. what Grafana Cloud exported is they use a different pluginVersion

Your file: 
"pluginVersion": "9.1.1",

Grafana cloud:
"pluginVersion": "9.1.3-e1f2f3c",

This should be verified against local grafana to confirm it still works locally, but it should.
